### PR TITLE
correctly parsing to tuples on updates

### DIFF
--- a/pg/wal/heapdata_test.go
+++ b/pg/wal/heapdata_test.go
@@ -8,7 +8,7 @@ import "testing"
 
 func TestHeapDataExpectations(t *testing.T) {
 	for _, exp := range heapDataExpectations {
-		if act := NewHeapData(exp.typ, false, exp.bs); act[0].String() != exp.str {
+		if act := NewHeapData(exp.typ, false, exp.bs, 0xD066); act[0].String() != exp.str {
 			t.Errorf("expected %q but got %q", exp.str, act[0].String())
 		}
 	}

--- a/pg/wal/recordbody.go
+++ b/pg/wal/recordbody.go
@@ -50,7 +50,7 @@ func (r *RecordBody) IsComplete() bool {
 
 // HeapData interprets the body based on the type indicated in the record header
 func (r *RecordBody) HeapData() []HeapData {
-	return NewHeapData(r.typ, r.header.IsInit(), r.bs)
+	return NewHeapData(r.typ, r.header.IsInit(), r.bs, r.header.version)
 }
 
 func readBody(block []byte, location Location, length uint64) []byte {


### PR DESCRIPTION
Postgres moved the 'to' tuple by 8 bytes between 9.1 and 9.4 to make room for xmax/xmin