### PR TITLE
add a summary stream

### DIFF
--- a/message/message.go
+++ b/message/message.go
@@ -124,6 +124,27 @@ type Table struct {
 	Relation     string `json:"rel"`
 }
 
+//TxnSummary is a summary of a transaction instead of the contents of it
+type TxnSummary struct {
+	TransactionID uint32            `json:"xid"`
+	FirstKey      Key               `json:"first"`
+	CommitKey     Key               `json:"commit"`
+	CommitTime    time.Time         `json:"commit_time"`
+	PublishTime   time.Time         `json:"publish_time"`
+	MessageCount  int               `json:"message_count,omitempty"`
+	TupleLen      int64             `json:"tuple_len,omitempty"`
+	TotalLen      int64             `json:"total_len,omitempty"`
+	ServerVersion string            `json:"server_version,omitempty"`
+	Tables        map[Table]Summary `json:"tables"`
+}
+
+//Summary is summary information about message types
+type Summary struct {
+	Inserts int `json:"inserts"`
+	Updates int `json:"updates"`
+	Deletes int `json:"deletes"`
+}
+
 //RelFullName is a full table address of the form db.ns.table
 func (msg Table) RelFullName() string {
 	return fmt.Sprintf("%s.%s.%s", msg.DatabaseName, msg.Namespace, msg.Relation)

--- a/streams/summary.go
+++ b/streams/summary.go
@@ -1,0 +1,71 @@
+package streams
+
+import (
+	"time"
+
+	"github.com/MediaMath/keryxlib/message"
+	"github.com/MediaMath/keryxlib/pg/wal"
+)
+
+// Copyright 2015 MediaMath <http://www.mediamath.com>.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//SummaryStream returns a stream of message.TxnSummary
+type SummaryStream struct {
+	SchemaMetaInformation
+}
+
+//SchemaMetaInformation provides textual information from wal log entry ids
+type SchemaMetaInformation interface {
+	GetDatabaseName(databaseID uint32) string
+	GetNamespaceAndTable(databaseID uint32, relationID uint32) (string, string)
+}
+
+//Start takes the buffered wal log entries and creates message summaries for them
+func (s SummaryStream) Start(serverVersion string, entryChan <-chan []*wal.Entry) (<-chan message.TxnSummary, error) {
+	txns := make(chan message.TxnSummary)
+
+	go func() {
+		for entries := range entryChan {
+			if len(entries) > 0 {
+				txn := message.TxnSummary{}
+				txn.ServerVersion = serverVersion
+
+				commit := entries[len(entries)-1]
+				txn.TransactionID = commit.TransactionID
+				txn.CommitKey = createKey(commit)
+				txn.CommitTime = time.Unix(0, commit.ParseTime).UTC()
+				txn.MessageCount = len(entries)
+
+				txn.Tables = make(map[message.Table]message.Summary)
+				for _, entry := range entries {
+					if entry.Type == wal.Insert || entry.Type == wal.Update || entry.Type == wal.Delete {
+						table := message.Table{}
+						table.DatabaseName = s.GetDatabaseName(entry.DatabaseID)
+						table.Namespace, table.Relation = s.GetNamespaceAndTable(entry.DatabaseID, entry.RelationID)
+
+						summary := txn.Tables[table]
+
+						switch entry.Type {
+						case wal.Insert:
+							summary.Inserts++
+						case wal.Update:
+							summary.Updates++
+						case wal.Delete:
+							summary.Deletes++
+						}
+
+						txn.Tables[table] = summary
+					}
+				}
+
+				txn.PublishTime = time.Now().UTC()
+				txns <- txn
+			}
+		}
+		close(txns)
+	}()
+
+	return txns, nil
+}

--- a/streams/summary_test.go
+++ b/streams/summary_test.go
@@ -1,0 +1,110 @@
+package streams
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MediaMath/keryxlib/message"
+	"github.com/MediaMath/keryxlib/pg/wal"
+)
+
+func TestCreateSummary(t *testing.T) {
+	sr := &testSchemaReader{
+		dbMap:  map[uint32]string{1: "foo"},
+		relMap: map[uint32]string{1: "bar.boo", 99: "baz.moo"},
+	}
+
+	entries := make(chan []*wal.Entry, 10)
+
+	entries <- []*wal.Entry{} //skipped
+
+	entries <- []*wal.Entry{
+		&wal.Entry{DatabaseID: 1, RelationID: 99, Type: wal.Insert},
+		&wal.Entry{DatabaseID: 1, RelationID: 1, Type: wal.Insert},
+		&wal.Entry{DatabaseID: 1, RelationID: 1, Type: wal.Insert},
+		&wal.Entry{DatabaseID: 1, RelationID: 99, Type: wal.Update},
+		&wal.Entry{DatabaseID: 1, RelationID: 1, Type: wal.Delete},
+		&wal.Entry{Type: wal.Commit, TransactionID: 88, TimelineID: 99, ReadFrom: wal.NewLocation(1, 2, 3, 4, 5)},
+	}
+
+	entries <- []*wal.Entry{
+		&wal.Entry{DatabaseID: 1, RelationID: 1, Type: wal.Delete},
+		&wal.Entry{Type: wal.Commit, TransactionID: 93, TimelineID: 99, ReadFrom: wal.NewLocation(1, 2, 3, 4, 5)},
+	}
+
+	close(entries)
+
+	summaries, err := SummaryStream{sr}.Start("boom", entries)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	count := 0
+	for summary := range summaries {
+		count++
+		if count > 2 {
+			t.Fatal("Got more than 2 records")
+		}
+
+		switch count {
+		case 1:
+			if summary.ServerVersion != "boom" || summary.MessageCount != 6 || summary.TransactionID != 88 {
+				t.Errorf("Incorrect summary for 1: %v", summary)
+			}
+
+			if len(summary.Tables) != 2 {
+				t.Fatalf("Didn't get tables: %v", summary.Tables)
+			}
+
+			boo := summary.Tables[message.Table{DatabaseName: "foo", Namespace: "bar", Relation: "boo"}]
+			moo := summary.Tables[message.Table{DatabaseName: "foo", Namespace: "baz", Relation: "moo"}]
+
+			if boo.Inserts != 2 || boo.Deletes != 1 || boo.Updates != 0 {
+				t.Errorf("Incorrect boo: %v", boo)
+			}
+
+			if moo.Inserts != 1 || moo.Deletes != 0 || moo.Updates != 1 {
+				t.Errorf("Incorrect moo: %v", moo)
+			}
+		case 2:
+			if summary.ServerVersion != "boom" || summary.MessageCount != 2 || summary.TransactionID != 93 {
+				t.Errorf("Incorrect summary for 2: %v", summary)
+			}
+
+			if len(summary.Tables) != 1 {
+				t.Fatalf("Didn't get tables: %v", summary.Tables)
+			}
+
+			boo := summary.Tables[message.Table{DatabaseName: "foo", Namespace: "bar", Relation: "boo"}]
+
+			if boo.Inserts != 0 || boo.Deletes != 1 || boo.Updates != 0 {
+				t.Errorf("Incorrect boo: %v", boo)
+			}
+		}
+	}
+
+	if count < 2 {
+		t.Fatalf("Didn't get all summaries: %v", count)
+	}
+}
+
+type testSchemaReader struct {
+	dbMap  map[uint32]string
+	relMap map[uint32]string
+}
+
+func (t *testSchemaReader) GetDatabaseName(databaseID uint32) string {
+	return t.dbMap[databaseID]
+}
+
+func (t *testSchemaReader) GetNamespaceAndTable(databaseID uint32, relationID uint32) (string, string) {
+	s := t.relMap[relationID]
+
+	pairs := strings.Split(s, ".")
+	if len(pairs) != 2 {
+		return "", ""
+	}
+
+	return pairs[0], pairs[1]
+}


### PR DESCRIPTION
This adds a new stream type that instead of populating the wal entries in a transaction just gathers summary statistics for them.  This should be lighterweight.

Note it still needs DB connectivity for determining ns/rel names.