### PR TITLE
attempt to fix smoke tests to work with pg 9.4

### DIFF
--- a/smokeTests/common.bash
+++ b/smokeTests/common.bash
@@ -3,6 +3,8 @@ setup () {
 	SCRIPT_PATH=`dirname $0`
 	DATABASE_NAME=smoke_test
 
+	export PATH="/usr/lib/postgresql/9.4/bin:$PATH"
+
 	prepare_temp_dir () {
 		TEMP_PATH="$SCRIPT_PATH/tmp"
 		cleanup_temp_dir


### PR DESCRIPTION
Upgrading the build server to postgres 9.4 appears to have broken the smoke tests.  This is a quick fix to add the pg tools into the path in hopes that it fixes them.