### PR TITLE
making field values consistent with psql

### DIFF
--- a/pg/detect_pg_version.go
+++ b/pg/detect_pg_version.go
@@ -12,7 +12,7 @@ import (
 )
 
 //ErrIncorrectVersion is returned when a non supported postgres is found.
-var ErrIncorrectVersion = errors.New("Only postgres 9.1 is supported.")
+var ErrIncorrectVersion = errors.New("only postgres 9.1 is supported")
 
 //IsPgVersionSupported returns an error if the postgres version is not supported currently.
 func IsPgVersionSupported(versionFilePath string) error {

--- a/pg/schema_reader.go
+++ b/pg/schema_reader.go
@@ -77,13 +77,14 @@ func (s *Schema) GetTextColumnQuery(sizeLimit int) (names []string, err error) {
 		return nil, fmt.Errorf("no access to schema for %v, %v.%v", s.Database, s.Namespace, s.Table)
 	}
 
-	cast := fmt.Sprintf("::char varying(%v)", sizeLimit)
-	if sizeLimit < 1 {
-		cast = "::text"
-	}
-
-	for _, field := range s.Fields {
-		names = append(names, fmt.Sprintf("coalesce(%v%v, '') as \"%v\"", field.Column, cast, field.Column))
+	if sizeLimit > 0 {
+		for _, field := range s.Fields {
+			names = append(names, fmt.Sprintf("format('%%s', %v)::char varying(%v) as \"%v\"", field.Column, sizeLimit, field.Column))
+		}
+	} else {
+		for _, field := range s.Fields {
+			names = append(names, fmt.Sprintf("format('%%s', %v) as \"%v\"", field.Column, field.Column))
+		}
 	}
 
 	return names, nil

--- a/tko/cli.go
+++ b/tko/cli.go
@@ -22,13 +22,13 @@ func GetConditionFromArgsOrStdIn(ctx *cli.Context) (Condition, error) {
 	if doesFileHaveInput(os.Stdin) {
 		bytes, err := ioutil.ReadAll(os.Stdin)
 		if err != nil {
-			return nil, fmt.Errorf("Error reading stdin: %v", err)
+			return nil, fmt.Errorf("error reading stdin: %v", err)
 		}
 
 		return ReadConditionFromJSON(string(bytes))
 	}
 
-	return nil, fmt.Errorf("No query provided.")
+	return nil, fmt.Errorf("no query provided")
 }
 
 func doesFileHaveInput(file *os.File) bool {

--- a/tko/conditions.go
+++ b/tko/conditions.go
@@ -102,7 +102,7 @@ func (c *Not) Check(txn *message.Transaction) bool {
 
 func (c *Not) validate() error {
 	if c.condition == nil {
-		return fmt.Errorf("No condition to invert.")
+		return fmt.Errorf("no condition to invert")
 	}
 
 	return nil
@@ -269,7 +269,7 @@ func (c *HasMessage) Check(txn *message.Transaction) bool {
 
 func (c *HasMessage) validate() error {
 	if c.Waits == nil && c.Type == nil && c.DatabaseName == nil && c.Namespace == nil && c.Relation == nil && c.TupleID == nil && c.PrevTupleID == nil && len(c.FieldsMatch) == 0 && c.MissingFields == nil {
-		return fmt.Errorf("No message conditions specified.")
+		return fmt.Errorf("no message conditions specified")
 	}
 
 	return nil


### PR DESCRIPTION
Specifically bools that are casted with `bool_field::text` end up as 'true' where as psql chooses to display as 't'.  It seems better to standardize on what psql chose rather than have two different representations for the same value.